### PR TITLE
Add decoding and encoding to string for Graph

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,15 +13,15 @@ jobs:
   test:
     strategy:
       matrix:
-        elixir: ['1.8', '1.9', '1.10', '1.11']
+        elixir: ["1.8", "1.9", "1.10", "1.11"]
 
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
-          otp-version: '22.3.4'
+          otp-version: "22.3.4"
           elixir-version: ${{ matrix.elixir }}
 
       - uses: actions-rs/toolchain@v1

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ erl_crash.dump
 imageflow_ex-*.tar
 
 native/imageflow_ex/target/
+priv/

--- a/lib/imageflow/graph.ex
+++ b/lib/imageflow/graph.ex
@@ -124,12 +124,8 @@ defmodule Imageflow.Graph do
   Check the official [encoding documentation](https://docs.imageflow.io/json/encode.html) to see the parameters available to each encoder
   """
   @spec encode_to_file(t, binary, binary | atom, map) :: t
-  def encode_to_file(%{io_count: io_count} = graph, path, encoder \\ :png, opts \\ %{}) do
-    io_id = io_count + 1
-
-    graph
-    |> add_output(io_id, {:file, path})
-    |> append_node(%{encode: %{io_id: io_id, preset: preset_for(encoder, opts)}})
+  def encode_to_file(graph, path, encoder \\ :png, opts \\ %{}) do
+    add_encode_node(graph, {:file, path}, encoder, opts)
   end
 
   @doc """
@@ -155,11 +151,15 @@ defmodule Imageflow.Graph do
   """
 
   @spec encode_to_string(t, binary | atom, map) :: t
-  def encode_to_string(%{io_count: io_count} = graph, encoder \\ :png, opts \\ %{}) do
+  def encode_to_string(graph, encoder \\ :png, opts \\ %{}) do
+    add_encode_node(graph, :bytes, encoder, opts)
+  end
+
+  defp add_encode_node(%{io_count: io_count} = graph, output_type, encoder, opts) do
     io_id = io_count + 1
 
     graph
-    |> add_output(io_id, :bytes)
+    |> add_output(io_id, output_type)
     |> append_node(%{encode: %{io_id: io_id, preset: preset_for(encoder, opts)}})
   end
 

--- a/lib/imageflow/graph.ex
+++ b/lib/imageflow/graph.ex
@@ -355,6 +355,8 @@ defmodule Imageflow.Graph do
     GraphRunner.run(graph)
   end
 
+  def get_results(job, graph), do: GraphRunner.get_results(job, graph)
+
   defp add_input(%{io_count: io_count, inputs: inputs} = graph, io_id, value) do
     %{graph | io_count: io_count + 1, inputs: Map.put(inputs, io_id, value)}
   end

--- a/lib/imageflow/graph.ex
+++ b/lib/imageflow/graph.ex
@@ -102,7 +102,6 @@ defmodule Imageflow.Graph do
     |> append_node(%{decode: %{io_id: io_id}})
   end
 
-
   @doc """
   Specifies a destination file for the current branch of the pipeline
 

--- a/lib/imageflow/graph.ex
+++ b/lib/imageflow/graph.ex
@@ -91,6 +91,19 @@ defmodule Imageflow.Graph do
   end
 
   @doc """
+  Appends a string to be decoded
+  """
+  @spec decode_string(t, binary) :: t
+  def decode_string(%{io_count: io_count} = graph, string) do
+    io_id = io_count + 1
+
+    graph
+    |> add_input(io_id, {:bytes, string})
+    |> append_node(%{decode: %{io_id: io_id}})
+  end
+
+
+  @doc """
   Specifies a destination file for the current branch of the pipeline
 
   No further processing operations should be appended at the current branch after this call.
@@ -117,6 +130,37 @@ defmodule Imageflow.Graph do
 
     graph
     |> add_output(io_id, {:file, path})
+    |> append_node(%{encode: %{io_id: io_id, preset: preset_for(encoder, opts)}})
+  end
+
+  @doc """
+  Returns the converted image as a string.
+
+  No further processing operations should be appended at the current branch after this call.
+
+  The last two arguments specify the encoder and optional encoding parameters.
+
+  The following parameters are valid encoders:
+  * `:jpg`: Alias to `:mozjpeg`
+  * `:jpeg`: Alias to `:mozjpeg`
+  * `:png`: Alias to `:lodepng`
+  * `:webp: Alias to `:webplossless
+  * `:mozjpeg`
+  * `:gif`
+  * `:lodepng`: Lossless PNG
+  * `:pngquant`: Lossy PNG
+  * `:webplossy`: Lossy WebP
+  * `:webplossless`: Lossless WebP
+
+  Check the official [encoding documentation](https://docs.imageflow.io/json/encode.html) to see the parameters available to each encoder
+  """
+
+  @spec encode_to_string(t, binary | atom, map) :: t
+  def encode_to_string(%{io_count: io_count} = graph, encoder \\ :png, opts \\ %{}) do
+    io_id = io_count + 1
+
+    graph
+    |> add_output(io_id, :bytes)
     |> append_node(%{encode: %{io_id: io_id, preset: preset_for(encoder, opts)}})
   end
 

--- a/lib/imageflow/graph_runner.ex
+++ b/lib/imageflow/graph_runner.ex
@@ -7,7 +7,7 @@ defmodule Imageflow.GraphRunner do
          :ok <- add_outputs(job, graph.outputs),
          :ok <- send_task(job, graph),
          :ok <- save_outputs(job, graph.outputs) do
-      {:ok, job}
+      {:ok, job, graph}
     end
   end
 
@@ -52,13 +52,10 @@ defmodule Imageflow.GraphRunner do
   defp add_outputs(job, inputs) do
     inputs
     |> Enum.reduce_while(:ok, fn
-      {id, value}, :ok ->
-        case value do
-          {:file, _path} -> Native.add_output_buffer(job, id)
-          :bytes -> Native.add_output_buffer(job, id)
-        end
-        |> case do
-          :ok -> {:cont, :ok}
+      {id, _}, :ok ->
+        with :ok <- Native.add_output_buffer(job, id) do
+          {:cont, :ok}
+        else
           {:error, _} = error -> {:halt, error}
         end
     end)

--- a/lib/imageflow/graph_runner.ex
+++ b/lib/imageflow/graph_runner.ex
@@ -7,8 +7,8 @@ defmodule Imageflow.GraphRunner do
          :ok <- add_outputs(job, graph.outputs),
          :ok <- send_task(job, graph),
          :ok <- save_outputs(job, graph.outputs),
-         :ok <- Native.destroy(job) do
-      :ok
+         {:ok, results} <- print_results(job, graph.outputs) do
+      if results == [], do: :ok, else: {:ok, results}
     end
   end
 
@@ -18,6 +18,7 @@ defmodule Imageflow.GraphRunner do
       {id, value}, :ok ->
         case value do
           {:file, path} -> Native.add_input_file(job, id, path)
+          {:bytes, blob} -> Native.add_input_buffer(job, id, blob)
         end
         |> case do
           :ok -> {:cont, :ok}
@@ -29,10 +30,13 @@ defmodule Imageflow.GraphRunner do
   defp add_outputs(job, inputs) do
     inputs
     |> Enum.reduce_while(:ok, fn
-      {id, _}, :ok ->
-        with :ok <- Native.add_output_buffer(job, id) do
-          {:cont, :ok}
-        else
+      {id, value}, :ok ->
+        case value do
+          {:file, _path} -> Native.add_output_buffer(job, id)
+          :bytes -> Native.add_output_buffer(job, id)
+        end
+        |> case do
+          :ok -> {:cont, :ok}
           {:error, _} = error -> {:halt, error}
         end
     end)
@@ -44,11 +48,27 @@ defmodule Imageflow.GraphRunner do
       {id, value}, :ok ->
         case value do
           {:file, path} -> Native.save_output_to_file(job, id, path)
+          :bytes -> :ok # skip
         end
         |> case do
           :ok -> {:cont, :ok}
           {:error, _} = error -> {:halt, error}
         end
+    end)
+  end
+
+  def print_results(job, outputs) do
+    outputs
+    |> Enum.reduce_while({:ok, []}, fn ({id, value}, {:ok, acc}) ->
+      case value do
+        :bytes -> Native.get_output_buffer(job, id)
+        {:file, _} -> :skip # skip
+      end
+      |> case do
+        :skip -> {:cont, {:ok, acc}}
+        {:ok, results} -> {:cont, {:ok, :binary.list_to_bin(results)}}
+        {:error, _} = error -> {:halt, error}
+      end
     end)
   end
 

--- a/lib/imageflow/graph_runner.ex
+++ b/lib/imageflow/graph_runner.ex
@@ -48,7 +48,8 @@ defmodule Imageflow.GraphRunner do
       {id, value}, :ok ->
         case value do
           {:file, path} -> Native.save_output_to_file(job, id, path)
-          :bytes -> :ok # skip
+          # skip
+          :bytes -> :ok
         end
         |> case do
           :ok -> {:cont, :ok}
@@ -59,10 +60,11 @@ defmodule Imageflow.GraphRunner do
 
   def print_results(job, outputs) do
     outputs
-    |> Enum.reduce_while({:ok, []}, fn ({id, value}, {:ok, acc}) ->
+    |> Enum.reduce_while({:ok, []}, fn {id, value}, {:ok, acc} ->
       case value do
         :bytes -> Native.get_output_buffer(job, id)
-        {:file, _} -> :skip # skip
+        # skip
+        {:file, _} -> :skip
       end
       |> case do
         :skip -> {:cont, {:ok, acc}}

--- a/lib/imageflow/native.ex
+++ b/lib/imageflow/native.ex
@@ -19,7 +19,7 @@ defmodule Imageflow.Native do
       {:ok, resp} = Native.message("v0.1/get_image_info", %{io_id: 0})
   """
 
-  alias Imageflow.NIF
+  alias Imageflow.{Graph, NIF}
 
   @type t :: %__MODULE__{}
   @type native_ret_t :: :ok | {:error, binary}
@@ -62,12 +62,12 @@ defmodule Imageflow.Native do
     NIF.job_save_output_to_file(id, io_id, path)
   end
 
-  @spec get_output_buffer(t, number) :: {:ok, binary} | {:error, binary}
+  @spec get_output_buffer(t, number) :: {:ok, iolist} | {:error, binary}
   def get_output_buffer(%__MODULE__{id: id} = _job, io_id) do
     NIF.job_get_output_buffer(id, io_id)
   end
 
-  @spec message(t, binary, binary) :: {:ok, any} | {:error, binary}
+  @spec message(t, binary, Graph.t()) :: {:ok, any} | {:error, binary}
   def message(%__MODULE__{id: id}, method, message) do
     with {:ok, resp} <- NIF.job_message(id, method, Jason.encode!(message)) do
       {:ok, Jason.decode!(resp)}

--- a/lib/imageflow/result.ex
+++ b/lib/imageflow/result.ex
@@ -1,0 +1,3 @@
+defmodule Imageflow.Result do
+  defstruct job: nil, graph: nil, output: nil
+end

--- a/test/imageflow/graph_test.exs
+++ b/test/imageflow/graph_test.exs
@@ -9,7 +9,7 @@ defmodule Imageflow.GraphTest do
     end
   end
 
-  describe "decode_file/1" do
+  describe "decode_file/2" do
     test "appends a new input" do
       graph = Graph.new() |> Graph.decode_file("file.png")
 
@@ -23,7 +23,23 @@ defmodule Imageflow.GraphTest do
     end
   end
 
-  describe "encode_file/1" do
+  describe "decode_string/2" do
+    test "appends a new input" do
+      {:ok, string} = File.read("test/fixtures/elixir-logo.jpg")
+      graph = Graph.new() |> Graph.decode_string(string)
+
+      assert %{io_count: 1, inputs: %{1 => {:bytes, _string}}} = graph
+    end
+
+    test "appends a file decoding operation" do
+      {:ok, string} = File.read("test/fixtures/elixir-logo.jpg")
+      graph = Graph.new() |> Graph.decode_string(string)
+
+      assert %{nodes: %{1 => %{decode: %{io_id: 1}}}} = graph
+    end
+  end
+
+  describe "encode_to_file/2" do
     test "appends a new output" do
       graph = Graph.new() |> Graph.encode_to_file("file.png")
 
@@ -86,6 +102,74 @@ defmodule Imageflow.GraphTest do
 
     test "allows appending webp outputs with custom parameters" do
       graph = Graph.new() |> Graph.encode_to_file("file.webp", :webp, %{a: :b})
+
+      assert %{nodes: %{1 => %{encode: %{io_id: 1, preset: :webplossless}}}} = graph
+    end
+  end
+
+  describe "encode_to_string/2" do
+    test "appends a new output" do
+      graph = Graph.new() |> Graph.encode_to_string()
+
+      assert %{io_count: 1, outputs: %{1 => :bytes}} = graph
+    end
+
+    test "appends a file encoding operation" do
+      graph = Graph.new() |> Graph.encode_to_string()
+
+      assert %{nodes: %{1 => %{encode: %{io_id: 1}}}} = graph
+    end
+
+    test "allows appending jpg outputs" do
+      graph = Graph.new() |> Graph.encode_to_string(:jpg)
+
+      assert %{nodes: %{1 => %{encode: %{io_id: 1, preset: %{mozjpeg: %{quality: 90}}}}}} = graph
+    end
+
+    test "allows appending jpg outputs with custom parameters" do
+      graph = Graph.new() |> Graph.encode_to_string(:jpg, %{quality: 10})
+
+      assert %{nodes: %{1 => %{encode: %{io_id: 1, preset: %{mozjpeg: %{quality: 10}}}}}} = graph
+    end
+
+    test "allows appending png outputs" do
+      graph = Graph.new() |> Graph.encode_to_string(:png)
+
+      assert %{
+               nodes: %{
+                 1 => %{encode: %{io_id: 1, preset: %{lodepng: %{maximum_deflate: false}}}}
+               }
+             } = graph
+    end
+
+    test "allows appending png outputs with custom parameters" do
+      graph = Graph.new() |> Graph.encode_to_string(:png, %{maximum_deflate: true})
+
+      assert %{
+               nodes: %{1 => %{encode: %{io_id: 1, preset: %{lodepng: %{maximum_deflate: true}}}}}
+             } = graph
+    end
+
+    test "allows appending gif outputs" do
+      graph = Graph.new() |> Graph.encode_to_string(:gif)
+
+      assert %{nodes: %{1 => %{encode: %{io_id: 1, preset: :gif}}}} = graph
+    end
+
+    test "allows appending gif outputs with custom parameters" do
+      graph = Graph.new() |> Graph.encode_to_string(:gif, %{a: :b})
+
+      assert %{nodes: %{1 => %{encode: %{io_id: 1, preset: :gif}}}} = graph
+    end
+
+    test "allows appending webp outputs" do
+      graph = Graph.new() |> Graph.encode_to_string(:webp)
+
+      assert %{nodes: %{1 => %{encode: %{io_id: 1, preset: :webplossless}}}} = graph
+    end
+
+    test "allows appending webp outputs with custom parameters" do
+      graph = Graph.new() |> Graph.encode_to_string(:webp, %{a: :b})
 
       assert %{nodes: %{1 => %{encode: %{io_id: 1, preset: :webplossless}}}} = graph
     end

--- a/test/integration/graph_test.exs
+++ b/test/integration/graph_test.exs
@@ -1,21 +1,23 @@
 defmodule Imageflow.Integration.GraphTest do
   use ExUnit.Case
 
-  alias Imageflow.{Graph, Native}
+  alias Imageflow.{Graph, Native, Result}
 
   @input_path "test/fixtures/elixir-logo.jpg"
   @output_path "/tmp/output.png"
 
   test "can pipe multiple operations" do
-    assert :ok =
-             Graph.new()
-             |> Graph.decode_file(@input_path)
-             |> Graph.constrain(20, 20)
-             |> Graph.rotate_270()
-             |> Graph.transpose()
-             |> Graph.color_filter("invert")
-             |> Graph.encode_to_file(@output_path)
-             |> Graph.run()
+    run_result =
+      Graph.new()
+      |> Graph.decode_file(@input_path)
+      |> Graph.constrain(20, 20)
+      |> Graph.rotate_270()
+      |> Graph.transpose()
+      |> Graph.color_filter("invert")
+      |> Graph.encode_to_file(@output_path)
+      |> Graph.run()
+
+    assert match?({:ok, _job, _graph}, run_result)
   end
 
   test "can generate multiple images" do
@@ -47,12 +49,28 @@ defmodule Imageflow.Integration.GraphTest do
   end
 
   test "can handle multiple operations" do
-    assert :ok =
-             Graph.new()
-             |> Graph.decode_file(@input_path)
-             |> Graph.flip_vertical()
-             |> Graph.transpose()
-             |> Graph.encode_to_file("/tmp/rotated.png")
-             |> Graph.run()
+    run_result =
+      Graph.new()
+      |> Graph.decode_file(@input_path)
+      |> Graph.flip_vertical()
+      |> Graph.transpose()
+      |> Graph.encode_to_file("/tmp/rotated.png")
+      |> Graph.run()
+
+    assert match?({:ok, _job, _graph}, run_result)
+  end
+
+  test "can encode to file" do
+    {:ok, job, graph} =
+      Graph.new()
+      |> Graph.decode_file(@input_path)
+      |> Graph.flip_vertical()
+      |> Graph.transpose()
+      |> Graph.encode_to_string()
+      |> Graph.run()
+
+    {:ok, %Result{} = results} = Graph.get_results(job, graph)
+
+    assert is_bitstring(results.output)
   end
 end


### PR DESCRIPTION
I wanted to add on-fly conversion, without saving files anywhere on disk, but send the stream directly to GCloud. As I know it is possible using the low-level API, but it was missing from high-level API.
This PR shouldn't affect current I/O, it just adds new features.